### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ iOS application written in [Swift](https://developer.apple.com/swift/).
 
 Icon by: [Rodrigo Nascimento](https://github.com/rodrigok) (tks :D)
 
-**IMPORTANT:** *This project uses [Cocoapods](http://cocoapods.org/) as the dependency manager, make sure you have it installed. After download or clone it, apply the following command in the directory of the project:
+**IMPORTANT:** *This project uses [CocoaPods](http://cocoapods.org/) as the dependency manager, make sure you have it installed. After download or clone it, apply the following command in the directory of the project:
 ```bash 
 pod install 
 ``` 


### PR DESCRIPTION
This pull request corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
